### PR TITLE
feat: rename infractl to terranova env vars

### DIFF
--- a/terranova/binds.py
+++ b/terranova/binds.py
@@ -53,7 +53,7 @@ class Terraform(Bind):
         def is_allowed_env_var(env_var: str) -> bool:
             return (
                 env_var.startswith("TF_")
-                or env_var.startswith("INFRACTL_")
+                or env_var.startswith("TERRANOVA_")
                 # Implicit credentials for s3 backend
                 or env_var.startswith("AWS_")
                 or env_var in ["HOME", "PATH"]

--- a/terranova/resources.py
+++ b/terranova/resources.py
@@ -67,9 +67,9 @@ class ResourcesRunbook:
     def exec(self, path: str, workdir: Path) -> None:
         """Try to execute the runbook."""
         env = {
-            "INFRACTL_PATH": path,
-            "INFRACTL_CONF_DIR": SharedContext.conf_dir().absolute().as_posix(),
-            "INFRACTL_RUNBOOK_NAME": self.name,
+            "TERRANOVA_PATH": path,
+            "TERRANOVA_CONF_DIR": SharedContext.conf_dir().absolute().as_posix(),
+            "TERRANOVA_RUNBOOK_NAME": self.name,
         }
         if os.getenv("PATH"):
             env["PATH"] = os.getenv("PATH")

--- a/terranova/terranova.py
+++ b/terranova/terranova.py
@@ -35,7 +35,7 @@ from .utils import SharedContext
     help="Conf directory path.",
     type=click.Path(exists=True, path_type=Path),
     required=True,
-    envvar="INFRACTL_CONF_DIR",
+    envvar="TERRANOVA_CONF_DIR",
     default="./conf",
 )
 @click.version_option(__version__)


### PR DESCRIPTION
## What is the change being made?

* Rename remaining environment variables related to `infractl`.

## Why is the change being made?

* Rename everything before going public.