### PR TITLE
fix: correctly forward runbook env vars

### DIFF
--- a/terranova/commands.py
+++ b/terranova/commands.py
@@ -32,6 +32,7 @@ from .exceptions import (
     AmbiguousRunbookError,
     InvalidResourcesError,
     ManifestError,
+    MissingRunbookEnvError,
     MissingRunbookError,
 )
 from .resources import Resource, ResourcesFinder, ResourcesManifest
@@ -484,5 +485,7 @@ def runbook(path: str, name: str) -> None:
     executable_runbook = next(iter(matching_runbooks))
     try:
         executable_runbook.exec(path, full_path / "runbooks")
+    except MissingRunbookEnvError as err:
+        Log.failure("find environment variable", err, raise_exit=1)
     except sh.ErrorReturnCode as err:
         raise Exit(code=err.exit_code) from err

--- a/terranova/exceptions.py
+++ b/terranova/exceptions.py
@@ -123,3 +123,14 @@ class MissingRunbookError(RunbookError):
             cause=f"The runbook `{name}` isn't defined`",
             resolution="Ensure the runbook is defined.",
         )
+
+
+class MissingRunbookEnvError(RunbookError):
+    """Represents a missing runbook environment variables error."""
+
+    def __init__(self, env_name: str) -> None:
+        """Init missing runbook environment variables error."""
+        super().__init__(
+            cause=f"The environment variable `{env_name}` isn't defined.",
+            resolution="Ensure the environment variable is defined before running the runbook.",
+        )


### PR DESCRIPTION
## What is the change being made?

* Implement a specific error when a runbook env var is missing.

## Why is the change being made?

* Currently, `terranova` exits with a traceback when an env var is missing.
