### PR TITLE
fix: exclude header in the templates file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ deps = ["env:configure"]
 help = "Add license header in codebase."
 sequence = [
     { cmd = "licenseheaders -t .copyright.tmpl -d scripts" },
-    { cmd = "licenseheaders -t .copyright.tmpl -d terranova" },
+    { cmd = "licenseheaders -t .copyright.tmpl -d terranova --exclude terranova/templates/resources.md" },
 ]
 
 [tool.poe.tasks.wipe]

--- a/terranova/templates/resources.md
+++ b/terranova/templates/resources.md
@@ -1,21 +1,3 @@
-<!--
-Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-or more contributor license agreements. See the NOTICE file distributed with
-this work for additional information regarding copyright
-ownership. Elasticsearch B.V. licenses this file to you under
-the Apache License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 # {{ manifest.metadata.name }}
 
 *{{ manifest.metadata.description }}*


### PR DESCRIPTION
Avoid headers in the `template` file.

Otherwise, the generated docs will contain a header and that's likely too invasive as consumers don't need to use any Elastic license headers.

Regression from https://github.com/elastic/terranova/pull/15