### PR TITLE
feat: add `--detailed-exitcode` flag to `plan` command

### DIFF
--- a/terranova/binds.py
+++ b/terranova/binds.py
@@ -150,7 +150,9 @@ class Terraform(Bind):
         self._exec("fmt", _inherit=True)
 
     # pylint: disable=redefined-builtin
-    def plan(self, compact_warnings: bool, input: bool, no_color: bool, parallelism: int) -> None:
+    def plan(
+        self, compact_warnings: bool, input: bool, no_color: bool, parallelism: int, detailed_exitcode: bool
+    ) -> None:
         """Show changes required by the current configuration."""
         args = ["plan"]
         if compact_warnings:
@@ -160,6 +162,8 @@ class Terraform(Bind):
             args.append("-no-color")
         if parallelism and parallelism != 10:  # Default value is 10
             args.append(f"-parallelism={parallelism}")
+        if detailed_exitcode:
+            args.append("-detailed-exitcode")
         self._exec(*args, _inherit=True)
 
     def apply(self, auto_approve: bool = False, target: str | None = None) -> None:

--- a/terranova/commands/binds.py
+++ b/terranova/commands/binds.py
@@ -277,9 +277,27 @@ def docs(docs_dir: Path) -> None:
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--detailed-exitcode",
+    help="""
+    \b
+    Return detailed exit codes when the command exits.
+    This will change the meaning of exit codes to:
+    0 - Succeeded, diff is empty (no changes)
+    1 - Errored
+    2 - Succeeded, there is a diff
+    """,
+    is_flag=True,
+)
 # pylint: disable-next=R0913
 def plan(
-    path: str | None, compact_warnings: bool, input: bool, no_color: bool, parallelism: int, fail_at_end: bool
+    path: str | None,
+    compact_warnings: bool,
+    input: bool,
+    no_color: bool,
+    parallelism: int,
+    fail_at_end: bool,
+    detailed_exitcode: bool,
 ) -> None:
     """Show changes required by the current configuration."""
     # Find all resources manifests
@@ -297,7 +315,13 @@ def plan(
 
         # Execute plan command
         try:
-            terraform.plan(compact_warnings=compact_warnings, input=input, no_color=no_color, parallelism=parallelism)
+            terraform.plan(
+                compact_warnings=compact_warnings,
+                input=input,
+                no_color=no_color,
+                parallelism=parallelism,
+                detailed_exitcode=detailed_exitcode,
+            )
         except sh.ErrorReturnCode:
             errors = True
             if not fail_at_end:


### PR DESCRIPTION
We want to run a scheduled pipeline that checks if there is an unexpected diff.

This will help determine if there is a diff and fail the pipeline accordingly.