### PR TITLE
fix: put codeowners at same level

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # OBLT Robots owns the code
-* @elastic/observablt-ci
-* @amannocci
+* @elastic/observablt-ci @amannocci


### PR DESCRIPTION
## What is the change being made?

- Put codeowners at the same level.

## Why is the change being made?

- Order precedence matters