### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -24,14 +24,28 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Get token
+        id: get-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["terranova"]
+
       - uses: elastic/oblt-actions/git/setup@v1
         with:
-          github-token: ${{ secrets.EPHEMERAL_GH_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}
 
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          token: ${{ secrets.EPHEMERAL_GH_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           fetch-depth: 0
 
       - name: Install environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,27 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Get token
+        id: get-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write"
+            }
+          repositories: >-
+            ["terranova"]
+
       - uses: elastic/oblt-actions/git/setup@v1
         with:
-          github-token: ${{ secrets.EPHEMERAL_GH_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}
 
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          token: ${{ secrets.EPHEMERAL_GH_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           fetch-depth: 0
 
       - name: Install environment


### PR DESCRIPTION
## What does this PR do?

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.

## Why is it important?

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the GH workflow requires to run in terms of access
* GitHub Token with Permissions does not trigger GitHub builds 

#### Implementation details

Use `tibdex/github-app-token` with the required permissions and the repository scope
Configure git checkout with the ephemeral token
