### PR TITLE
ci: Add GH_TOKEN to post-release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,4 @@ jobs:
         run: poetry run poe release:post
         env:
           NEXT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
Fixes https://github.com/elastic/terranova/actions/runs/11662386289/job/32468971182