### PR TITLE
fix: write plan to out when exit code is 2

### DIFF
--- a/terranova/commands/binds.py
+++ b/terranova/commands/binds.py
@@ -351,14 +351,13 @@ def plan(
             if not fail_at_end:
                 break
 
-    write_plan = lambda: (
+    def write_plan():
         out.write_text(json.dumps(execution_plan))
-        and Log.action(
+        Log.action(
             f"Saved terranova plan to: {out}\n\n"
             f"To perform exactly these actions with terranova, run the following command to apply:\n"
             f'    terranova apply "{out}"'
         )
-    )
 
     # Report any errors if fail_at_end has been enabled
     if errors:


### PR DESCRIPTION
## Context

The added `--out` option in 0.6.0 does not create a plan file if the command exits with a non-zero exit code.

However, when using `--detailed-exitcode`, `2` is a successful exit code indicating that the plan was successful but there are changes.

## Changes

This will create the tnplan file if the also if the exit code is 2.

