### PR TITLE
ci: use runner os instead of os matrix

### DIFF
--- a/.github/workflows/env-install/action.yml
+++ b/.github/workflows/env-install/action.yml
@@ -5,11 +5,11 @@ runs:
   using: "composite"
   steps:
     - name: Set up QEMU
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      if: matrix.os == 'ubuntu-latest'
+      if: runner.os == 'Linux'
       uses: docker/setup-buildx-action@v3
 
     - name: Install uv


### PR DESCRIPTION
## What is the change being made?

- Use runner os instead of os matrix.

## Why is the change being made?

- The action must be able to run outside matrix scope.