### PR TITLE
feat: support `install.sh` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,15 @@ jobs:
 
       - name: Test
         run: uv run poe test
+
+  test-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: run install.sh
+        run: ./install.sh
+
+      - name: run terranova
+        run: |-
+          terranova --version

--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ brew tap elastic/terranova
 brew install terranova
 ```
 
+### Single-line installation
+
+```shell
+curl -sSL https://raw.githubusercontent.com/elastic/terranova/0.6.5/install.sh | sh -s
+```
+
+If you use `wget` instead:
+
+```shell
+wget -qO- https://raw.githubusercontent.com/elastic/terranova/0.6.5/install.sh | sh -s
+```
+
+That will download `terranova`, put it inside `/usr/local/bin/` and give it execution rights with `chmod`.
+
 ### How to install as Standalone
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 
 ## NOTE: Bump this version when a new release.
-VERSION=0.6.4
+VERSION="0.6.4"
 OS=$(uname -s| tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
 if [ "${ARCH}" = "aarch64" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o nounset
+
+## NOTE: Bump this version when a new release.
+VERSION=0.6.4
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" = "aarch64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+elif [ "${ARCH}" = "x86_64" ] ; then
+    GVM_ARCH_SUFFIX=amd64
+elif [ "${ARCH}" = "arm64" ] ; then
+    GVM_ARCH_SUFFIX=arm64
+else
+    echo "Unsupported architecture: ${ARCH}"
+    exit 1
+fi
+
+URL="https://github.com/elastic/terranova/releases/download/${VERSION}/terranova-${VERSION}-${OS}-${GVM_ARCH_SUFFIX}"
+
+LOCATION="/usr/local/bin"
+curl -sSLo "$LOCATION/terranova" "$URL"
+chmod +x "$LOCATION/terranova"

--- a/install.sh
+++ b/install.sh
@@ -8,17 +8,17 @@ VERSION="0.6.4"
 OS=$(uname -s| tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
 if [ "${ARCH}" = "aarch64" ] ; then
-    GVM_ARCH_SUFFIX=arm64
+    ARCH_SUFFIX=arm64
 elif [ "${ARCH}" = "x86_64" ] ; then
-    GVM_ARCH_SUFFIX=amd64
+    ARCH_SUFFIX=amd64
 elif [ "${ARCH}" = "arm64" ] ; then
-    GVM_ARCH_SUFFIX=arm64
+    ARCH_SUFFIX=arm64
 else
     echo "Unsupported architecture: ${ARCH}"
     exit 1
 fi
 
-URL="https://github.com/elastic/terranova/releases/download/${VERSION}/terranova-${VERSION}-${OS}-${GVM_ARCH_SUFFIX}"
+URL="https://github.com/elastic/terranova/releases/download/${VERSION}/terranova-${VERSION}-${OS}-${ARCH_SUFFIX}"
 
 LOCATION="/usr/local/bin"
 curl -sSLo "$LOCATION/terranova" "$URL"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,6 +70,30 @@ def __set_version(version: str) -> None:
         raise err
 
 
+def __set_version_install_file(version: str) -> None:
+    # Update install file version version
+    try:
+        data = Constants.INSTALL_PATH.read_text()
+    except Exception as err:
+        print(
+            f"The `{Constants.INSTALL_PATH.as_posix()}` can't be read",
+            file=sys.stderr,
+        )
+        raise err
+
+    data = re.sub(
+        r"VERSION=\"(.*)\"", f'VERSION="{version}"', data, count=1
+    )
+    try:
+        Constants.INSTALL_PATH.write_text(data)
+    except Exception as err:
+        print(
+            f"The `{Constants.INSTALL_PATH.as_posix()}` file can't be written",
+            file=sys.stderr,
+        )
+        raise err
+
+
 def pre() -> None:
     # Ensure we have inputs
     release_version = os.getenv("RELEASE_VERSION")
@@ -89,6 +113,9 @@ def pre() -> None:
 
     # Update all files
     __set_version(release_version)
+
+    # Update install file
+    __set_version_install_file(release_version)
 
     # Push release branch
     git("add", "--all", _out=sys.stdout, _err=sys.stderr)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -34,6 +34,7 @@ class Constants:
     PYRIGHTCONFIG_PATH: Final[Path] = Path("pyrightconfig.json")
     REGISTRY_URL: str = os.getenv("REGISTRY_URL", "local.dev")
     TERRANOVA_INIT_PATH: Final[Path] = Path("./terranova/__init__.py")
+    INSTALL_PATH: Final[Path] = Path("install.sh")
 
 
 def fatal(msg: str, err: Exception | None = None) -> NoReturn:


### PR DESCRIPTION
## What is the change being made?

Add `instal.sh` file

## Why is the change being made?

Help consumers to install the binary with one single-line command.

## How has this been tested?

In the CI

## How has this been documented?

Yes

## Related Issues
