### PR TITLE
ci(release): fix branch name and skip install validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
 
   test-install:
     runs-on: ubuntu-latest
+    # If you change the branch name in  scripts/release.py please
+    # update the condition below.
+    # We cannot test the install if the release has not happened yet.
+    if: ${{ !startsWith(github.ref, 'refs/heads/feat/pre-release-v') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -107,7 +107,9 @@ def pre() -> None:
         )
 
     # Create a new branch
-    branch_name = f"release/v{release_version}"
+    # TODO: if you change the branch_name, please update the
+    #       condition at .github/workflows/ci.yml
+    branch_name = f"feat/pre-release-v{release_version}"
     git = detect_git()
     git("checkout", "-b", branch_name, _out=sys.stdout, _err=sys.stderr)
 


### PR DESCRIPTION
Branch name is protected, let's use a different one.

Install for the pre-release points to the upcoming release, so let's skip it for now