### PR TITLE
ci: use uv with frozen setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Ref: https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date
+  UV_FROZEN: "true"
+
 ## Concurrency only allowed in the main branch.
 ## So old builds running for old commits within the same Pull Request are cancelled
 concurrency:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Ref: https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date
+  UV_FROZEN: "true"
+
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Ref: https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date
+  UV_FROZEN: "true"
+
 concurrency:
   group: ${{ github.workflow }}
 

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Ref: https://docs.astral.sh/uv/concepts/projects/sync/#checking-if-the-lockfile-is-up-to-date
+  UV_FROZEN: "true"
+
 jobs:
   compose:
     runs-on: ubuntu-latest

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,9 +81,7 @@ def __set_version_install_file(version: str) -> None:
         )
         raise err
 
-    data = re.sub(
-        r"VERSION=\"(.*)\"", f'VERSION="{version}"', data, count=1
-    )
+    data = re.sub(r"VERSION=\"(.*)\"", f'VERSION="{version}"', data, count=1)
     try:
         Constants.INSTALL_PATH.write_text(data)
     except Exception as err:


### PR DESCRIPTION
## 🧑‍💻 What is the change being made?

- Set frozen environment variable to avoid `uv.lock` updates within CI.

## :question: Why is the change being made?

- The `uv.lock` should not be updated within the CI.

