### PR TITLE
ci: exclude for PRs related to the release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     # If you change the branch name in  scripts/release.py please
     # update the condition below.
     # We cannot test the install if the release has not happened yet.
-    if: ${{ !startsWith(github.head_ref, 'feat/pre-release-v') }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'feat/pre-release-v') && !startsWith(github.head_ref, 'feat/post-release-v') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -182,6 +182,8 @@ def post() -> None:
         return print("The `NEXT_VERSION` should match semver format.", file=sys.stderr)
 
     # Create a new branch
+    # TODO: if you change the branch_name, please update the
+    #       condition at .github/workflows/ci.yml
     branch_name = f"feat/post-release-v{next_version}"
     git = detect_git()
     git("checkout", "-b", branch_name, _out=sys.stdout, _err=sys.stderr)


### PR DESCRIPTION
## 🧑‍💻What is the change being made?

Avoid running the install before any release has happended

## :question: Why is the change being made?

Otherwise, the release is not available and the check will fail

## :white_check_mark: How has this been tested?

In the CI

## :books: How has this been documented?

## :link: Related Issues
